### PR TITLE
Instantiate new ZidRecord for new entries

### DIFF
--- a/src/gnu/java/zrtp/zidfile/ZidFile.java
+++ b/src/gnu/java/zrtp/zidfile/ZidFile.java
@@ -250,6 +250,7 @@ public class ZidFile {
         // If we reached end of file, then no record with matching ZID
         // found. We need to create a new ZID record.
         if (!numRead) {
+            rec = new ZidRecord();
             rec.setIdentifier(zid);
             rec.setValid();
             try {


### PR DESCRIPTION
Before this commit, a new entry in the ZidFile copies the retained secrets and flags from the last saved ZidRecord. Then new devices could be treated like they should have a secret retained, which would raise an invalid security warning in the implementing client.

@dschuermann